### PR TITLE
IOError fix

### DIFF
--- a/lib/murasaki.rb
+++ b/lib/murasaki.rb
@@ -3,5 +3,6 @@ require 'nio'
 
 require_relative 'murasaki/version'
 require_relative 'murasaki/event_loop'
+require_relative 'murasaki/io'
 require_relative 'murasaki/timer'
 require_relative 'murasaki/promise'

--- a/lib/murasaki/event_loop.rb
+++ b/lib/murasaki/event_loop.rb
@@ -67,11 +67,14 @@ module EventLoop
     # @param [IO] io io to deregister
     # @return [nil] nil
     def deregister(io)
-      fd = io.to_i
       @selector.deregister(io)
       @ios.delete(io)
-      next_register = @queue[fd].shift
-      next_register.nil? ? @queue.delete(fd) : register_raw(*next_register)
+      unless io.closed?
+        # Will it cause memory leak?
+        fd = io.fileno
+        next_register = @queue[fd].shift
+        next_register.nil? ? @queue.delete(fd) : register_raw(*next_register)
+      end
       nil
     end
 

--- a/lib/murasaki/io.rb
+++ b/lib/murasaki/io.rb
@@ -1,0 +1,11 @@
+##
+# Meta-programming IO for Safety Check
+class IO
+  raw_close = instance_method(:close)
+
+  define_method(:close) do
+    # Be sure to clean the queue
+    EventLoop.release_queue(self)
+    raw_close.bind(self).()
+  end
+end


### PR DESCRIPTION
This is a quick fix to avoid IOError reported in #9 and https://github.com/midori-rb/midori.rb/issues/155 .

But this would cause memory leak in some situations. The `register` method should be totally rewritten.